### PR TITLE
nose -> pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            python-version: [3.6, 3.7, 3.8, 3.9]
-            os: [macOs-latest, ubuntu-latest, windows-latest]
+            python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+            os: [macos-latest, ubuntu-latest, windows-latest]
 
     runs-on:  ${{ matrix.os }}
     name: run tests
@@ -25,7 +25,7 @@ jobs:
       - name: test
         run: |
           pip freeze
-          nosetests --verbosity=3 --with-coverage --cover-package pyexcel_ods --cover-package tests tests --with-doctest --doctest-extension=.rst README.rst docs/source pyexcel_ods
+          pytest
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:

--- a/README.rst
+++ b/README.rst
@@ -353,7 +353,7 @@ and update CHANGELOG.rst.
 How to test your contribution
 ------------------------------
 
-Although `nose` and `doctest` are both used in code testing, it is adviable that unit tests are put in tests. `doctest` is incorporated only to make sure the code examples in documentation remain valid across different development releases.
+Although `pytest` and `doctest` are both used in code testing, it is adviable that unit tests are put in tests. `doctest` is incorporated only to make sure the code examples in documentation remain valid across different development releases.
 
 On Linux/Unix systems, please launch your tests like this::
 

--- a/pyexcel_ods/odsr.py
+++ b/pyexcel_ods/odsr.py
@@ -7,6 +7,7 @@
     :copyright: (c) 2014-2020 by Onni Software Ltd.
     :license: New BSD License, see LICENSE for more details
 """
+
 # Copyright 2011 Marco Conti
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyexcel_ods/odsw.py
+++ b/pyexcel_ods/odsw.py
@@ -7,6 +7,7 @@
     :copyright: (c) 2014-2020 by Onni Software Ltd.
     :license: New BSD License, see LICENSE for more details
 """
+
 import pyexcel_io.service as converter
 from odf.text import P
 from odf.table import Table, TableRow, TableCell

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=pyexcel_ods --doctest-glob="*.rst" tests/ README.rst docs/source pyexcel_ods

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ if __name__ == "__main__":
         keywords=KEYWORDS,
         python_requires=PYTHON_REQUIRES,
         extras_require=EXTRAS_REQUIRE,
-        tests_require=["nose"],
+        tests_require=["pytest", "pytest-cov"],
         install_requires=INSTALL_REQUIRES,
         packages=PACKAGES,
         include_package_data=True,

--- a/test.bat
+++ b/test.bat
@@ -1,2 +1,2 @@
 pip freeze
-nosetests --with-coverage --cover-package pyexcel_ods --cover-package tests tests --with-doctest --doctest-extension=.rst README.rst docs/source pyexcel_ods
+pytest

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 #/bin/bash
 pip freeze
-nosetests --with-coverage --cover-package pyexcel_ods --cover-package tests tests --with-doctest --doctest-extension=.rst README.rst docs/source pyexcel_ods
+pytest

--- a/tests/base.py
+++ b/tests/base.py
@@ -29,7 +29,7 @@ class PyexcelHatWriterBase:
     def test_series_table(self):
         pyexcel.save_as(adict=self.content, dest_file_name=self.testfile)
         r = pyexcel.get_sheet(file_name=self.testfile, name_columns_by_row=0)
-        eq_(r.dict, self.content)
+        assert r.dict == self.content
 
 
 class PyexcelWriterBase:
@@ -96,46 +96,45 @@ class ODSCellTypes:
     def test_formats(self):
         # date formats
         date_format = "%d/%m/%Y"
-        eq_(self.data["Sheet1"][0][0], "Date")
-        eq_(self.data["Sheet1"][1][0].strftime(date_format), "11/11/2014")
-        eq_(self.data["Sheet1"][2][0].strftime(date_format), "01/01/2001")
-        eq_(self.data["Sheet1"][3][0], "")
+        assert self.data["Sheet1"][0][0] == "Date"
+        assert self.data["Sheet1"][1][0].strftime(date_format) == "11/11/2014"
+        assert self.data["Sheet1"][2][0].strftime(date_format) == "01/01/2001"
+        assert self.data["Sheet1"][3][0] == ""
         # time formats
         time_format = "%S:%M:%H"
-        eq_(self.data["Sheet1"][0][1], "Time")
-        eq_(self.data["Sheet1"][1][1].strftime(time_format), "12:12:11")
-        eq_(self.data["Sheet1"][2][1].strftime(time_format), "12:00:00")
-        eq_(self.data["Sheet1"][3][1], 0)
-        eq_(
-            self.data["Sheet1"][4][1],
-            datetime.timedelta(hours=27, minutes=17, seconds=54),
-        )
-        eq_(self.data["Sheet1"][5][1], "Other")
+        assert self.data["Sheet1"][0][1] == "Time"
+        assert self.data["Sheet1"][1][1].strftime(time_format) == "12:12:11"
+        assert self.data["Sheet1"][2][1].strftime(time_format) == "12:00:00"
+        assert self.data["Sheet1"][3][1] == 0
+        assert (
+            self.data["Sheet1"][4][1] ==
+            datetime.timedelta(hours=27, minutes=17, seconds=54))
+        assert self.data["Sheet1"][5][1] == "Other"
         # boolean
-        eq_(self.data["Sheet1"][0][2], "Boolean")
-        eq_(self.data["Sheet1"][1][2], True)
-        eq_(self.data["Sheet1"][2][2], False)
+        assert self.data["Sheet1"][0][2] == "Boolean"
+        assert self.data["Sheet1"][1][2] == True
+        assert self.data["Sheet1"][2][2] == False
         # Float
-        eq_(self.data["Sheet1"][0][3], "Float")
-        eq_(self.data["Sheet1"][1][3], 11.11)
+        assert self.data["Sheet1"][0][3] == "Float"
+        assert self.data["Sheet1"][1][3] == 11.11
         # Currency
-        eq_(self.data["Sheet1"][0][4], "Currency")
-        eq_(self.data["Sheet1"][1][4], "1 GBP")
-        eq_(self.data["Sheet1"][2][4], "-10000 GBP")
+        assert self.data["Sheet1"][0][4] == "Currency"
+        assert self.data["Sheet1"][1][4] == "1 GBP"
+        assert self.data["Sheet1"][2][4] == "-10000 GBP"
         # Percentage
-        eq_(self.data["Sheet1"][0][5], "Percentage")
-        eq_(self.data["Sheet1"][1][5], 2)
+        assert self.data["Sheet1"][0][5] == "Percentage"
+        assert self.data["Sheet1"][1][5] == 2
         # int
-        eq_(self.data["Sheet1"][0][6], "Int")
-        eq_(self.data["Sheet1"][1][6], 3)
-        eq_(self.data["Sheet1"][4][6], 11)
+        assert self.data["Sheet1"][0][6] == "Int"
+        assert self.data["Sheet1"][1][6] == 3
+        assert self.data["Sheet1"][4][6] == 11
         # Scientifed not supported
-        eq_(self.data["Sheet1"][1][7], 100000)
+        assert self.data["Sheet1"][1][7] == 100000
         # Fraction
-        eq_(self.data["Sheet1"][1][8], 1.25)
+        assert self.data["Sheet1"][1][8] == 1.25
         # Text
-        eq_(self.data["Sheet1"][1][9], "abc")
+        assert self.data["Sheet1"][1][9] == "abc"
 
         @raises(IndexError)
         def test_no_excessive_trailing_columns(self):
-            eq_(self.data["Sheet1"][2][6], "")
+            assert self.data["Sheet1"][2][6] == ""

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,9 +1,9 @@
 import os  # noqa
 import datetime  # noqa
 
+import pytest
 import pyexcel
 
-import pytest
 
 def create_sample_file1(file):
     data = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", 1.1, 1]
@@ -82,7 +82,7 @@ class PyexcelMultipleSheetBase:
         expected = [[4, 4, 4, 4], [5, 5, 5, 5], [6, 6, 6, 6]]
         assert data == expected
         data = list(b["Sheet3"].rows())
-        expected = [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]
+        expected = [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]
         assert data == expected
         sheet3 = b["Sheet3"]
         sheet3.name_columns_by_row(0)
@@ -105,9 +105,9 @@ class ODSCellTypes:
         assert self.data["Sheet1"][1][1].strftime(time_format) == "12:12:11"
         assert self.data["Sheet1"][2][1].strftime(time_format) == "12:00:00"
         assert self.data["Sheet1"][3][1] == 0
-        assert (
-            self.data["Sheet1"][4][1] ==
-            datetime.timedelta(hours=27, minutes=17, seconds=54))
+        assert self.data["Sheet1"][4][1] == datetime.timedelta(
+            hours=27, minutes=17, seconds=54
+        )
         assert self.data["Sheet1"][5][1] == "Other"
         # boolean
         assert self.data["Sheet1"][0][2] == "Boolean"

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,8 +3,7 @@ import datetime  # noqa
 
 import pyexcel
 
-from nose.tools import eq_, raises  # noqa
-
+import pytest
 
 def create_sample_file1(file):
     data = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", 1.1, 1]
@@ -135,6 +134,6 @@ class ODSCellTypes:
         # Text
         assert self.data["Sheet1"][1][9] == "abc"
 
-        @raises(IndexError)
         def test_no_excessive_trailing_columns(self):
-            assert self.data["Sheet1"][2][6] == ""
+            with pytest.raises(IndexError):
+                assert self.data["Sheet1"][2][6] == ""

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,6 @@
-nose
-mock;python_version<"3"
+pytest
+pytest-cov
 codecov
-coverage
 flake8
 black
 isort

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -15,7 +15,7 @@ IN_TRAVIS = "TRAVIS" in os.environ
 
 def test_bug_fix_for_issue_1():
     data = get_data(get_fixtures("repeated.ods"))
-    eq_(data["Sheet1"], [["repeated", "repeated", "repeated", "repeated"]])
+    assert data["Sheet1"] == [["repeated", "repeated", "repeated", "repeated"]]
 
 
 def test_bug_fix_for_issue_2():
@@ -61,7 +61,7 @@ def test_issue_13():
     data = [[1, 2], [], [], [], [3, 4]]
     save_data(test_file, {test_file: data})
     written_data = get_data(test_file, skip_empty_rows=False)
-    eq_(data, written_data[test_file])
+    assert data == written_data[test_file]
     os.unlink(test_file)
 
 
@@ -69,19 +69,19 @@ def test_issue_14():
     # pyexcel issue 61
     test_file = "issue_61.ods"
     data = get_data(get_fixtures(test_file), skip_empty_rows=True)
-    eq_(data["S-LMC"], [[u"aaa"], [0]])
+    assert data["S-LMC"] == [[u"aaa"], [0]]
 
 
 def test_issue_6():
     test_file = "12_day_as_time.ods"
     data = get_data(get_fixtures(test_file), skip_empty_rows=True)
-    eq_(data["Sheet1"][0][0].days, 12)
+    assert data["Sheet1"][0][0].days == 12
 
 
 def test_issue_19():
     test_file = "pyexcel_81_ods_19.ods"
     data = get_data(get_fixtures(test_file), skip_empty_rows=True)
-    eq_(data["product.template"][1][1], "PRODUCT NAME  PMP")
+    assert data["product.template"][1][1] == "PRODUCT NAME  PMP"
 
 
 def test_issue_83_ods_file_handle():
@@ -110,13 +110,13 @@ def test_issue_83_ods_file_handle():
     pe.free_resources()
     open_files_l4 = proc.open_files()
     # this confirms that no more open file handle
-    eq_(open_files_l1, open_files_l4)
+    assert open_files_l1 == open_files_l4
 
 
 def test_pr_22():
     test_file = get_fixtures("white_space.ods")
     data = get_data(test_file)
-    eq_(data["Sheet1"][0][0], "paragraph with tab(\t),    space, \nnew line")
+    assert data["Sheet1"][0][0] == "paragraph with tab(\t),    space, \nnew line"
 
 
 def test_issue_23():
@@ -133,13 +133,13 @@ def test_issue_23():
 def test_issue_24():
     test_file = get_fixtures("comment-in-cell.ods")
     data = get_data(test_file)
-    eq_(data["Sheet1"], [["test"]])
+    assert data["Sheet1"] == [["test"]]
 
 
 def test_issue_27():
     test_file = get_fixtures("issue_27.ods")
     data = get_data(test_file, skip_empty_rows=True)
-    eq_(data["VGPMX"], [["", "Cost Basis", "0"]])
+    assert data["VGPMX"] == [["", "Cost Basis", "0"]]
 
 
 def test_issue_30():
@@ -148,7 +148,7 @@ def test_issue_30():
     sheet[0, 0] = 999999999999999
     sheet.save_as(test_file)
     sheet2 = pe.get_sheet(file_name=test_file)
-    eq_(sheet[0, 0], sheet2[0, 0])
+    assert sheet[0, 0] == sheet2[0, 0]
     os.unlink(test_file)
 
 

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -7,7 +7,6 @@ import pyexcel as pe
 from pyexcel_ods import get_data, save_data
 from pyexcel_io.exceptions import IntegerAccuracyLossError
 
-from nose import SkipTest
 import pytest
 
 IN_TRAVIS = "TRAVIS" in os.environ
@@ -120,7 +119,7 @@ def test_pr_22():
 
 def test_issue_23():
     if not IN_TRAVIS:
-        raise SkipTest()
+        pytest.skip("Need to be in Travis CI to run this test.")
     pe.get_book(
         url=(
             "https://github.com/pyexcel/pyexcel-ods/"

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -8,7 +8,7 @@ from pyexcel_ods import get_data, save_data
 from pyexcel_io.exceptions import IntegerAccuracyLossError
 
 from nose import SkipTest
-from nose.tools import eq_, raises
+import pytest
 
 IN_TRAVIS = "TRAVIS" in os.environ
 
@@ -27,33 +27,32 @@ def test_bug_fix_for_issue_2():
     assert new_data["Sheet 2"] == [[u"row 1", u"H\xe9ll\xf4!", u"Hol\xc1!"]]
 
 
-@raises(Exception)
 def test_invalid_date():
-    from pyexcel_ods.ods import date_value
+    with pytest.raises(Exception):
+        from pyexcel_ods.ods import date_value
 
-    value = "2015-08-"
-    date_value(value)
-
-
-@raises(Exception)
-def test_fake_date_time_10():
-    from pyexcel_ods.ods import date_value
-
-    date_value("1234567890")
+        value = "2015-08-"
+        date_value(value)
 
 
-@raises(Exception)
+    with pytest.raises(Exception):
+        from pyexcel_ods.ods import date_value
+
+        date_value("1234567890")
+
+
 def test_fake_date_time_19():
-    from pyexcel_ods.ods import date_value
+    with pytest.raises(Exception):
+        from pyexcel_ods.ods import date_value
 
-    date_value("1234567890123456789")
+        date_value("1234567890123456789")
 
 
-@raises(Exception)
 def test_fake_date_time_20():
-    from pyexcel_ods.ods import date_value
+    with pytest.raises(Exception):
+        from pyexcel_ods.ods import date_value
 
-    date_value("12345678901234567890")
+        date_value("12345678901234567890")
 
 
 def test_issue_13():
@@ -152,12 +151,12 @@ def test_issue_30():
     os.unlink(test_file)
 
 
-@raises(IntegerAccuracyLossError)
 def test_issue_30_precision_loss():
-    test_file = "issue_30_2.ods"
-    sheet = pe.Sheet()
-    sheet[0, 0] = 9999999999999999
-    sheet.save_as(test_file)
+    with pytest.raises(IntegerAccuracyLossError):
+        test_file = "issue_30_2.ods"
+        sheet = pe.Sheet()
+        sheet[0, 0] = 9999999999999999
+        sheet.save_as(test_file)
 
 
 def get_fixtures(filename):

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -3,11 +3,10 @@
 import os
 
 import psutil
+import pytest
 import pyexcel as pe
 from pyexcel_ods import get_data, save_data
 from pyexcel_io.exceptions import IntegerAccuracyLossError
-
-import pytest
 
 IN_TRAVIS = "TRAVIS" in os.environ
 
@@ -20,10 +19,10 @@ def test_bug_fix_for_issue_1():
 def test_bug_fix_for_issue_2():
     data = {}
     data.update({"Sheet 1": [[1, 2, 3], [4, 5, 6]]})
-    data.update({"Sheet 2": [[u"row 1", u"Héllô!", u"HolÁ!"]]})
+    data.update({"Sheet 2": [["row 1", "Héllô!", "HolÁ!"]]})
     save_data("your_file.ods", data)
     new_data = get_data("your_file.ods")
-    assert new_data["Sheet 2"] == [[u"row 1", u"H\xe9ll\xf4!", u"Hol\xc1!"]]
+    assert new_data["Sheet 2"] == [["row 1", "H\xe9ll\xf4!", "Hol\xc1!"]]
 
 
 def test_invalid_date():
@@ -32,7 +31,6 @@ def test_invalid_date():
 
         value = "2015-08-"
         date_value(value)
-
 
     with pytest.raises(Exception):
         from pyexcel_ods.ods import date_value
@@ -67,7 +65,7 @@ def test_issue_14():
     # pyexcel issue 61
     test_file = "issue_61.ods"
     data = get_data(get_fixtures(test_file), skip_empty_rows=True)
-    assert data["S-LMC"] == [[u"aaa"], [0]]
+    assert data["S-LMC"] == [["aaa"], [0]]
 
 
 def test_issue_6():
@@ -114,7 +112,9 @@ def test_issue_83_ods_file_handle():
 def test_pr_22():
     test_file = get_fixtures("white_space.ods")
     data = get_data(test_file)
-    assert data["Sheet1"][0][0] == "paragraph with tab(\t),    space, \nnew line"
+    assert (
+        data["Sheet1"][0][0] == "paragraph with tab(\t),    space, \nnew line"
+    )
 
 
 def test_issue_23():

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -2,8 +2,6 @@ import os
 
 from pyexcel_io import get_data, save_data
 
-from nose.tools import eq_
-
 
 class TestFilter:
     def setup_method(self):

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -24,21 +24,21 @@ class TestFilter:
             self.test_file, start_row=3, library="pyexcel-ods"
         )
         expected = [[4, 24, 34], [5, 25, 35], [6, 26, 36]]
-        eq_(filtered_data[self.sheet_name], expected)
+        assert filtered_data[self.sheet_name] == expected
 
     def test_filter_row_2(self):
         filtered_data = get_data(
             self.test_file, start_row=3, row_limit=1, library="pyexcel-ods"
         )
         expected = [[4, 24, 34]]
-        eq_(filtered_data[self.sheet_name], expected)
+        assert filtered_data[self.sheet_name] == expected
 
     def test_filter_column(self):
         filtered_data = get_data(
             self.test_file, start_column=1, library="pyexcel-ods"
         )
         expected = [[21, 31], [22, 32], [23, 33], [24, 34], [25, 35], [26, 36]]
-        eq_(filtered_data[self.sheet_name], expected)
+        assert filtered_data[self.sheet_name] == expected
 
     def test_filter_column_2(self):
         filtered_data = get_data(
@@ -48,14 +48,14 @@ class TestFilter:
             library="pyexcel-ods",
         )
         expected = [[21], [22], [23], [24], [25], [26]]
-        eq_(filtered_data[self.sheet_name], expected)
+        assert filtered_data[self.sheet_name] == expected
 
     def test_filter_both_ways(self):
         filtered_data = get_data(
             self.test_file, start_column=1, start_row=3, library="pyexcel-ods"
         )
         expected = [[24, 34], [25, 35], [26, 36]]
-        eq_(filtered_data[self.sheet_name], expected)
+        assert filtered_data[self.sheet_name] == expected
 
     def test_filter_both_ways_2(self):
         filtered_data = get_data(
@@ -67,7 +67,7 @@ class TestFilter:
             library="pyexcel-ods",
         )
         expected = [[24]]
-        eq_(filtered_data[self.sheet_name], expected)
+        assert filtered_data[self.sheet_name] == expected
 
     def tearDown(self):
         os.unlink(self.test_file)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,7 +6,7 @@ from nose.tools import eq_
 
 
 class TestFilter:
-    def setUp(self):
+    def setup_method(self):
         self.test_file = "test_filter.ods"
         sample = [
             [1, 21, 31],
@@ -69,5 +69,5 @@ class TestFilter:
         expected = [[24]]
         assert filtered_data[self.sheet_name] == expected
 
-    def tearDown(self):
+    def teardown_method(self):
         os.unlink(self.test_file)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -21,7 +21,7 @@ class TestAutoDetectInt:
         | 1 | 2 | 3.1 |
         +---+---+-----+"""
         ).strip()
-        eq_(str(sheet), expected)
+        assert str(sheet) == expected
 
     def test_get_book_auto_detect_int(self):
         book = pe.get_book(file_name=self.test_file, library="pyexcel-ods")
@@ -32,7 +32,7 @@ class TestAutoDetectInt:
         | 1 | 2 | 3.1 |
         +---+---+-----+"""
         ).strip()
-        eq_(str(book), expected)
+        assert str(book) == expected
 
     def test_auto_detect_int_false(self):
         sheet = pe.get_sheet(
@@ -47,7 +47,7 @@ class TestAutoDetectInt:
         | 1.0 | 2.0 | 3.1 |
         +-----+-----+-----+"""
         ).strip()
-        eq_(str(sheet), expected)
+        assert str(sheet) == expected
 
     def test_get_book_auto_detect_int_false(self):
         book = pe.get_book(
@@ -62,7 +62,7 @@ class TestAutoDetectInt:
         | 1.0 | 2.0 | 3.1 |
         +-----+-----+-----+"""
         ).strip()
-        eq_(str(book), expected)
+        assert str(book) == expected
 
     def tearDown(self):
         os.unlink(self.test_file)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -3,8 +3,6 @@ from textwrap import dedent
 
 import pyexcel as pe
 
-from nose.tools import eq_
-
 
 class TestAutoDetectInt:
     def setup_method(self):

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -7,7 +7,7 @@ from nose.tools import eq_
 
 
 class TestAutoDetectInt:
-    def setUp(self):
+    def setup_method(self):
         self.content = [[1, 2, 3.1]]
         self.test_file = "test_auto_detect_init.ods"
         pe.save_as(array=self.content, dest_file_name=self.test_file)
@@ -64,5 +64,5 @@ class TestAutoDetectInt:
         ).strip()
         assert str(book) == expected
 
-    def tearDown(self):
+    def teardown_method(self):
         os.unlink(self.test_file)

--- a/tests/test_multiple_sheets.py
+++ b/tests/test_multiple_sheets.py
@@ -4,7 +4,7 @@ import sys
 import pyexcel
 from base import PyexcelMultipleSheetBase
 
-from nose.tools import raises
+import pytest
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     from ordereddict import OrderedDict
@@ -63,13 +63,13 @@ class TestAddBooks:
         assert len(b1.sheet_names()) == 1
         assert b1["Sheet1"].to_array() == self.content["Sheet1"]
 
-    @raises(IndexError)
     def test_load_a_single_sheet3(self):
-        pyexcel.get_book(file_name=self.testfile, sheet_index=10000)
+        with pytest.raises(IndexError):
+            pyexcel.get_book(file_name=self.testfile, sheet_index=10000)
 
-    @raises(ValueError)
     def test_load_a_single_sheet4(self):
-        pyexcel.get_book(file_name=self.testfile, sheet_name="Not exist")
+        with pytest.raises(ValueError):
+            pyexcel.get_book(file_name=self.testfile, sheet_name="Not exist")
 
     def test_delete_sheets(self):
         b1 = pyexcel.load_book(self.testfile)

--- a/tests/test_multiple_sheets.py
+++ b/tests/test_multiple_sheets.py
@@ -1,10 +1,9 @@
 import os
 import sys
 
+import pytest
 import pyexcel
 from base import PyexcelMultipleSheetBase
-
-import pytest
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     from ordereddict import OrderedDict
@@ -241,6 +240,6 @@ def _produce_ordered_dict():
     data_dict.update({"Sheet1": [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]]})
     data_dict.update({"Sheet2": [[4, 4, 4, 4], [5, 5, 5, 5], [6, 6, 6, 6]]})
     data_dict.update(
-        {"Sheet3": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
+        {"Sheet3": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
     )
     return data_dict

--- a/tests/test_multiple_sheets.py
+++ b/tests/test_multiple_sheets.py
@@ -13,24 +13,24 @@ else:
 
 
 class TestOdsNxlsMultipleSheets(PyexcelMultipleSheetBase):
-    def setUp(self):
+    def setup_method(self):
         self.testfile = "multiple1.ods"
         self.testfile2 = "multiple1.xls"
         self.content = _produce_ordered_dict()
         self._write_test_file(self.testfile)
 
-    def tearDown(self):
+    def teardown_method(self):
         self._clean_up()
 
 
 class TestXlsNOdsMultipleSheets(PyexcelMultipleSheetBase):
-    def setUp(self):
+    def setup_method(self):
         self.testfile = "multiple1.xls"
         self.testfile2 = "multiple1.ods"
         self.content = _produce_ordered_dict()
         self._write_test_file(self.testfile)
 
-    def tearDown(self):
+    def teardown_method(self):
         self._clean_up()
 
 
@@ -46,7 +46,7 @@ class TestAddBooks:
         self.rows = 3
         pyexcel.save_book_as(bookdict=self.content, dest_file_name=file)
 
-    def setUp(self):
+    def setup_method(self):
         self.testfile = "multiple1.ods"
         self.testfile2 = "multiple1.xls"
         self.content = _produce_ordered_dict()
@@ -218,7 +218,7 @@ class TestAddBooks:
         except TypeError:
             assert 1 == 1
 
-    def tearDown(self):
+    def teardown_method(self):
         if os.path.exists(self.testfile):
             os.unlink(self.testfile)
         if os.path.exists(self.testfile2):
@@ -226,7 +226,7 @@ class TestAddBooks:
 
 
 class TestMultiSheetReader:
-    def setUp(self):
+    def setup_method(self):
         self.testfile = "file_with_an_empty_sheet.ods"
 
     def test_reader_with_correct_sheets(self):

--- a/tests/test_ods_reader.py
+++ b/tests/test_ods_reader.py
@@ -7,7 +7,7 @@ from pyexcel_io.reader import Reader
 
 
 class TestODSReader(ODSCellTypes):
-    def setUp(self):
+    def setup_method(self):
         r = Reader("ods")
         r.reader_class = ODSBook
         r.open(os.path.join("tests", "fixtures", "ods_formats.ods"))
@@ -18,7 +18,7 @@ class TestODSReader(ODSCellTypes):
 
 
 class TestODSWriter(ODSCellTypes):
-    def setUp(self):
+    def setup_method(self):
         r = Reader("ods")
         r.reader_class = ODSBook
         r.open(os.path.join("tests", "fixtures", "ods_formats.ods"))
@@ -33,6 +33,6 @@ class TestODSWriter(ODSCellTypes):
         for key in self.data.keys():
             self.data[key] = list(self.data[key])
 
-    def tearDown(self):
+    def teardown_method(self):
         if os.path.exists(self.testfile):
             os.unlink(self.testfile)

--- a/tests/test_stringio.py
+++ b/tests/test_stringio.py
@@ -3,8 +3,6 @@ import os
 import pyexcel
 from base import create_sample_file1
 
-from nose.tools import eq_
-
 
 class TestStringIO:
     def test_ods_stringio(self):

--- a/tests/test_stringio.py
+++ b/tests/test_stringio.py
@@ -17,7 +17,7 @@ class TestStringIO:
             )
             result = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", 1.1, 1]
             actual = list(r.enumerate())
-            eq_(result, actual)
+            assert result == actual
         if os.path.exists(testfile):
             os.unlink(testfile)
 
@@ -29,4 +29,4 @@ class TestStringIO:
         )
         result = [1, 2, 3, 4, 5, 6]
         actual = list(r.enumerate())
-        eq_(result, actual)
+        assert result == actual

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -19,17 +19,17 @@ class TestNativeODSWriter:
         content = get_data(self.testfile, library="pyexcel-ods")
         assert content == self.content
 
-    def tearDown(self):
+    def teardown_method(self):
         if os.path.exists(self.testfile):
             os.unlink(self.testfile)
 
 
 class TestodsnCSVWriter(PyexcelWriterBase):
-    def setUp(self):
+    def setup_method(self):
         self.testfile = "test.ods"
         self.testfile2 = "test.csv"
 
-    def tearDown(self):
+    def teardown_method(self):
         if os.path.exists(self.testfile):
             os.unlink(self.testfile)
         if os.path.exists(self.testfile2):
@@ -37,9 +37,9 @@ class TestodsnCSVWriter(PyexcelWriterBase):
 
 
 class TestodsHatWriter(PyexcelHatWriterBase):
-    def setUp(self):
+    def setup_method(self):
         self.testfile = "test.ods"
 
-    def tearDown(self):
+    def teardown_method(self):
         if os.path.exists(self.testfile):
             os.unlink(self.testfile)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -10,7 +10,7 @@ class TestNativeODSWriter:
         self.content = {
             "Sheet1": [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]],
             "Sheet2": [[4, 4, 4, 4], [5, 5, 5, 5], [6, 6, 6, 6]],
-            "Sheet3": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]],
+            "Sheet3": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]],
         }
         self.testfile = "writer.ods"
         writer = Writer(self.testfile, "ods")


### PR DESCRIPTION
With your PR, here is a check list:

- [x] Has test cases written?
- [x] Has all code lines tested?
- [x] Has `make format` been run?
- [x] Please update CHANGELOG.yml(not CHANGELOG.rst)
- [x] Has fair amount of documentation if your change is complex
- [x] Agree on NEW BSD License for your contribution

This moves the project from the unmaintained nose test runner to pytest, which is a standard python test runner these days. The tests are equivalent and all pass, same as before, and coverage is still measured. Note that the codecov action included in the workflow right now does not function, as per codecov docs the `@v1` tag of codecov-action no longer functions.